### PR TITLE
add mich-h to VDOM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Awesome list of everything hyperscript
 ## VDOM
 
 - 🔌 https://github.com/Matt-Esch/virtual-dom
+- 🔌 https://github.com/tunnckoCore/mich-h
 
 ## App Frameworks
 


### PR DESCRIPTION
https://github.com/tunnckoCore/mich-h

Examples are currently broken, because relies on the v0.3.1 version. I'm gonna publish new release soon.